### PR TITLE
Allow compilation on Android API < 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ On the native side it uses [`JobScheduler`](https://developer.android.com/refere
 ## Requirements
 
 -   RN 0.36+
--   Android API 21+
 
 ## Supported platforms
 
--   Android
+-   Android (API 21+)
 
 Want iOS? Go in and vote for Headless JS to be implemented for iOS: [Product pains](https://productpains.com/post/react-native/headless-js-for-ios)
 
@@ -45,9 +44,9 @@ or
 
 #### Android
 
-1.  Open up `android/app/src/main/java/[...]/MainActivity.java`
+1.  Open up `android/app/src/main/java/[...]/MainApplication.java`
     -   Add `import com.pilloxa.backgroundjob.BackgroundJobPackage;` to the imports at the top of the file
-    -   Add `new BackgroundJobPackage()` to the list returned by the `getPackages()` method in `MainApplication.java`
+    -   Add `new BackgroundJobPackage()` to the list returned by the `getPackages()` method
 2.  Append the following lines to `android/settings.gradle`:
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.3"
-// Uncomment to develop with yarn link into node_modules
-//  compileOptions.incremental = false
+    // Uncomment to develop with yarn link into node_modules
+    // compileOptions.incremental = false
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
     compileOptions.incremental = false
     defaultConfig {
         applicationId "com.backtest"
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 "use strict";
 import { NativeModules, AppRegistry, Platform } from "react-native";
 
+// NOTE: This library is *not* currently supported on:
+// - iOS, any version
+// - Android, any version lower than 21 (5.0)
+const isSupported = Platform.OS === 'android' && Platform.Version >= 21
+
 const AppState = NativeModules.AppState;
 const tag = "BackgroundJob:";
-const jobModule = Platform.select({
-  ios: {},
-  android: NativeModules.BackgroundJob
-});
-const nativeJobs = Platform.select({
-  ios: { jobs: {} },
-  android: jobModule.jobs
-});
+const jobModule = isSupported ? NativeModules.BackgroundJob : {}
+const nativeJobs = isSupported ? jobModule.jobs : { jobs: [] }
+
 var jobs = {};
 var globalWarning = __DEV__;
 
@@ -18,6 +18,9 @@ const BackgroundJob = {
   NETWORK_TYPE_UNMETERED: jobModule.UNMETERED,
   NETWORK_TYPE_NONE: jobModule.NONE,
   NETWORK_TYPE_ANY: jobModule.ANY,
+
+  isSupported,
+
   /**
      * Registers jobs and the functions they should run. 
      * 
@@ -199,12 +202,17 @@ const BackgroundJob = {
     globalWarning = warn;
   }
 };
-if (Platform.OS == "ios") {
+
+if (!isSupported) {
+  const versionMessage = Platform.OS === 'ios'
+    ? 'iOS'
+    : 'versions of Android lower than 21 (5.0)'
+
   Object.keys(BackgroundJob).map(v => {
     BackgroundJob[v] = () => {
       if (globalWarning) {
         console.warn(
-          "react-native-background-job is not available on iOS yet. See https://github.com/vikeri/react-native-background-job#supported-platforms"
+          `react-native-background-job is not available on ${versionMessage} yet. See https://github.com/vikeri/react-native-background-job#supported-platforms`
         );
       }
     };


### PR DESCRIPTION
Fixes #14 

This PR switches the `minSdkVersion` back to 16, which is the minimum version RN supports. It now enforces the version constraint in the JS code just like the iOS check.

I've also added an `isSupported` key to allow an app to easily determine if background jobs are supported on the current device.