### PR TITLE
Fix not being able to stop foreground service

### DIFF
--- a/android/src/main/java/com/pilloxa/backgroundjob/BackgroundJobModule.java
+++ b/android/src/main/java/com/pilloxa/backgroundjob/BackgroundJobModule.java
@@ -132,7 +132,7 @@ public class BackgroundJobModule extends ReactContextBaseJavaModule implements L
         Log.d(LOG_TAG, "Cancelling job: " + jobKey + " (" + taskId + ")");
         jobScheduler.cancel(taskId);
         mJobs = jobScheduler.getAllPendingJobs();
-        if (mJobBundle != null && mJobBundle.getString("jobKey") == jobKey) {
+        if (mJobBundle != null && mJobBundle.getString("jobKey").equals(jobKey)) {
             cancelService();
         }
     }


### PR DESCRIPTION
Use `String.equals()` instead of `==` operator (same string vs same reference)

#32 