### PR TITLE
Fix documentation to match function name (fixes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Checks Whether app is optimising battery using Doze,returns Boolean.
 ```javascript
 import BackgroundJob from 'react-native-background-job';
 
-BackgroundJob.isAppIgnoringBatteryOptimisation((error,ignoringOptimization)=>{});
+BackgroundJob.isAppIgnoringBatteryOptimization((error,ignoringOptimization)=>{});
 ```
 
 ## Debugging

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ const BackgroundJob = {
    * @example
    * import BackgroundJob from 'react-native-background-job';
    *
-   * BackgroundJob.isAppIgnoringBatteryOptimisation((error,ignoringOptimization)=>{});
+   * BackgroundJob.isAppIgnoringBatteryOptimization((error,ignoringOptimization)=>{});
    */
   isAppIgnoringBatteryOptimization: function(callback) {
     jobModule.isAppIgnoringBatteryOptimization(ignoringOptimization => {


### PR DESCRIPTION
Although both spellings are correct, the function name uses z.