### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,31 +1,34 @@
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
-  repositories {
-    jcenter()
-    maven {
-      url 'https://maven.google.com/'
-      name 'Google'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
     }
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.1'
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.3")
+    }
   }
 }
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = '28.0.3'
-def DEFAULT_TARGET_SDK_VERSION = 28
-
 android {
-  compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-  buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+  compileSdkVersion safeExtGet('compileSdkVersion', 28)
+  buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   // Uncomment to develop with yarn link into node_modules
   //    compileOptions.incremental = false
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 28)
     versionCode 2
     versionName "2.0"
     ndk {
@@ -43,10 +46,7 @@ repositories {
     // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
     url "$rootDir/../node_modules/react-native/android"
   }
-  maven {
-    url 'https://maven.google.com/'
-    name 'Google'
-  }
+  google()
 }
 
 dependencies {
@@ -54,4 +54,3 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation 'androidx.annotation:annotation:1.1.0'
 }
-  


### PR DESCRIPTION
- Load Android Gradle Plugin conditionally

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

- used `google()` shortcut instead of 

```
maven {
    url 'https://maven.google.com/'
    name 'Google'
}
```

- used an auxiliary function to read root project gradle config instead of duplicating the code. also reading minSdkVersion from root project.